### PR TITLE
[WIP] Add Cloud Trace export for OpenTelemetry data

### DIFF
--- a/.github/workflows/sentiment-prod.yml
+++ b/.github/workflows/sentiment-prod.yml
@@ -41,7 +41,8 @@ jobs:
             --image gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{  github.sha }} \
             --platform managed \
             --port 8000 \
-            --memory "4Gi" 
+            --memory "4Gi" \
+            --update-env-vars ENVIRONMENT=gcp
 
     - name: Show Output
       run: echo ${{ steps.deploy.outputs.url }}

--- a/review-sentiment/sentiment-backend/requirements-cuda.txt
+++ b/review-sentiment/sentiment-backend/requirements-cuda.txt
@@ -10,6 +10,7 @@ opentelemetry-api==0.17b0
 opentelemetry-sdk==0.17b0
 opentelemetry-instrumentation-fastapi==0.17b0
 opentelemetry-exporter-jaeger==0.17b0
+opentelemetry-exporter-google-cloud==0.16b1
 
 --find-links https://download.pytorch.org/whl/cu100/torch_stable.html
 torch==1.4.0

--- a/review-sentiment/sentiment-backend/requirements.txt
+++ b/review-sentiment/sentiment-backend/requirements.txt
@@ -11,6 +11,7 @@ opentelemetry-api==0.17b0
 opentelemetry-sdk==0.17b0
 opentelemetry-instrumentation-fastapi==0.17b0
 opentelemetry-exporter-jaeger==0.17b0
+opentelemetry-exporter-google-cloud==0.16b1
 
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==1.7.1+cpu

--- a/review-sentiment/sentiment-backend/sentiment/tracing.py
+++ b/review-sentiment/sentiment-backend/sentiment/tracing.py
@@ -26,6 +26,14 @@ def set_up_tracing(settings: Settings):
         trace.get_tracer_provider().add_span_processor(
             SimpleExportSpanProcessor(ConsoleSpanExporter())
         )
+    elif settings.environment == "gcp":
+        from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+        from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+        cloud_trace_exporter = CloudTraceSpanExporter()
+        trace.get_tracer_provider().add_span_processor(
+            BatchExportSpanProcessor(cloud_trace_exporter)
+        )
 
 
 def traced(func: Union[Callable, None] = None,

--- a/visual-inspection/inspection-backend/inspection/tracing.py
+++ b/visual-inspection/inspection-backend/inspection/tracing.py
@@ -26,6 +26,14 @@ def set_up_tracing(settings: Settings):
         trace.get_tracer_provider().add_span_processor(
             SimpleExportSpanProcessor(ConsoleSpanExporter())
         )
+    elif settings.environment == "gcp":
+        from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+        from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+        cloud_trace_exporter = CloudTraceSpanExporter()
+        trace.get_tracer_provider().add_span_processor(
+            BatchExportSpanProcessor(cloud_trace_exporter)
+        )
 
 
 def traced(func: Union[Callable, None] = None,

--- a/visual-inspection/inspection-backend/requirements.txt
+++ b/visual-inspection/inspection-backend/requirements.txt
@@ -11,6 +11,7 @@ opentelemetry-api==0.17b0
 opentelemetry-sdk==0.17b0
 opentelemetry-instrumentation-fastapi==0.17b0
 opentelemetry-exporter-jaeger==0.17b0
+opentelemetry-exporter-google-cloud==0.16b1
 
 tensorflow-cpu==2.4.1
 Pillow==8.1.0


### PR DESCRIPTION
In preparation of our GCP deployment.

Build fails due to version conflicts, we can probably wait for the next release of https://github.com/GoogleCloudPlatform/opentelemetry-operations-python or downgrade all opentelemetry dependencies.