### PR TITLE
Update experiment-tracker.yml

### DIFF
--- a/.github/workflows/experiment-tracker.yml
+++ b/.github/workflows/experiment-tracker.yml
@@ -135,13 +135,8 @@ jobs:
           cd ./experiment-tracker
           docker-compose down
 
-  build-collector:
-    runs-on: ubuntu-latest
-    needs:
-      - integration-tests
-    if: github.ref == 'refs/heads/master'
-    steps:
       - name: Create data-collector container and publish to Registry
+        if: github.ref == 'refs/heads/master'
         uses: elgohr/Publish-Docker-Github-Action@3.04
         with:
           name: xai-demonstrator/data-collector
@@ -150,13 +145,9 @@ jobs:
           registry: ghcr.io
           workdir: experiment-tracker/
 
-  build-proxy:
-    runs-on: ubuntu-latest
-    needs:
-      - integration-tests
-    if: github.ref == 'refs/heads/master'
-    steps:
+
       - name: Create experiment-proxy container and publish to Registry
+        if: github.ref == 'refs/heads/master'
         uses: elgohr/Publish-Docker-Github-Action@3.04
         with:
           name: xai-demonstrator/experiment-proxy

--- a/.github/workflows/experiment-tracker.yml
+++ b/.github/workflows/experiment-tracker.yml
@@ -135,24 +135,38 @@ jobs:
           cd ./experiment-tracker
           docker-compose down
 
+  build-collector:
+    runs-on: ubuntu-latest
+    needs:
+      - integration-tests
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Create data-collector container and publish to Registry
-        if: github.ref == 'refs/heads/master'
         uses: elgohr/Publish-Docker-Github-Action@3.04
         with:
           name: xai-demonstrator/data-collector
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
-          workdir: experiment-tracker/
+          workdir: experiment-tracker/data-collector/
 
+  build-proxy:
+    runs-on: ubuntu-latest
+    needs:
+      - integration-tests
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Create experiment-proxy container and publish to Registry
-        if: github.ref == 'refs/heads/master'
         uses: elgohr/Publish-Docker-Github-Action@3.04
         with:
           name: xai-demonstrator/experiment-proxy
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
-          workdir: experiment-tracker/
-
+          workdir: experiment-tracker/experiment-proxy/


### PR DESCRIPTION
Im aktuellen Workflow findet er das Directory nicht und pusht deshalb nie die Container. Ich hab schon alle möglichen Directories ausprobiert und nie klappt es. Jetzt wollte ich den Worklfow mal so anpassen, näher an der alten Version dennoch mit   if: github.ref == 'refs/heads/master' vielleicht funktioniert er ja so.