### PR TITLE
Fix nr of rounds and Selection for control group gtc

### DIFF
--- a/guess-the-country/country-frontend/src/App.vue
+++ b/guess-the-country/country-frontend/src/App.vue
@@ -66,9 +66,7 @@
       </button>
       <!-- what do you guess, AI Button - control group -->
       <button
-get_url_query_parameters_gtc
           v-if="showAIGuessButton&&control&&round<=numOfRounds"
-
           type="button"
           class="xd-button xd-secondary"
           id="submit"

--- a/guess-the-country/country-frontend/src/App.vue
+++ b/guess-the-country/country-frontend/src/App.vue
@@ -42,6 +42,7 @@
           :sequence_mode="sequenceMode"
           :prediction_city="prediction_city"
           :explanation="explanation"
+          :control = "control"
       />
       <!-- what do you guess, AI Button - treatment group -->
       <button
@@ -66,7 +67,7 @@
       <!-- what do you guess, AI Button - control group -->
       <button
 get_url_query_parameters_gtc
-          v-if="showAIGuessButton&&control&&round!=numOfRounds"
+          v-if="showAIGuessButton&&control&&round<=numOfRounds"
 
           type="button"
           class="xd-button xd-secondary"

--- a/guess-the-country/country-frontend/src/components/Selection.vue
+++ b/guess-the-country/country-frontend/src/components/Selection.vue
@@ -27,16 +27,21 @@ export default {
     prediction_city: {
       type: String,
     },
-    explanation: {
+      explanation: {
       type: Object,
     },
+    control: {
+      type: Boolean,
+    }
   },
+
   computed: {
-    showSelection() {
-      if (this.sequence_mode === 'classic' || this.sequence_mode === 'basic') {
+    showSelection () {
+      if (this.sequence_mode==='classic'||this.sequence_mode==='basic'){
         return (!this.user_city_answer)
-      } else if (this.sequence_mode === 'recommender') {
-        return (this.prediction_city && !this.user_city_answer && this.explanation)
+      } else if (this.sequence_mode==='recommender'){
+          if (this.control){return (this.prediction_city&&!this.user_city_answer)}
+          else {return (this.prediction_city&&!this.user_city_answer&&this.explanation)}
       } else {
         return false
       }


### PR DESCRIPTION
Mir ist aufgefallen, dass die Kontrollgruppe (z.B.http://.../?modus=recommender&num_of_rounds=2&controll)

1. nur N-1 von N Runden effektiv spielen kann, da der Button "What do you guess, Ai?" in der vorletzten Runde nicht angezeigt wird
2. die Selection nicht angezeigt wird, da diese vorher unter anderem this.explanation!=null erforderte, was bei "control" allerdings nie erfolgt